### PR TITLE
NU-1: Resolve swift warning logs

### DIFF
--- a/NotchUtility/Services/DropUtility.swift
+++ b/NotchUtility/Services/DropUtility.swift
@@ -15,7 +15,7 @@ struct DropUtility {
         for provider in providers {
             if provider.canLoadObject(ofClass: URL.self) {
                 group.enter()
-                provider.loadObject(ofClass: URL.self) { url, error in
+                _ = provider.loadObject(ofClass: URL.self) { url, error in
                     defer { group.leave() }
                     
                     if let url = url, url.isFileURL {

--- a/NotchUtility/ViewModels/NotchViewModel+Events.swift
+++ b/NotchUtility/ViewModels/NotchViewModel+Events.swift
@@ -146,7 +146,7 @@ extension NotchViewModel {
         // Actually perform the haptic feedback when requested
         hapticSender
             .throttle(for: .seconds(0.5), scheduler: DispatchQueue.main, latest: false)
-            .sink { [weak self] _ in
+            .sink { _ in
                 NSHapticFeedbackManager.defaultPerformer.perform(
                     .levelChange,          // Subtle "level change" haptic (like adjusting volume)
                     performanceTime: .now  // Execute immediately

--- a/NotchUtility/ViewModels/NotchViewModel.swift
+++ b/NotchUtility/ViewModels/NotchViewModel.swift
@@ -32,7 +32,7 @@ import SwiftUI
 @MainActor
 class NotchViewModel: NSObject, ObservableObject {
     // === COMBINE SUBSCRIPTIONS ===
-    var cancellables: Set<AnyCancellable> = []    // Stores all event subscriptions for cleanup
+    nonisolated(unsafe) var cancellables: Set<AnyCancellable> = []    // Stores all event subscriptions for cleanup
     
     // === GEOMETRY CONFIGURATION ===
     let inset: CGFloat                            // Pixel adjustment for notch positioning (-4 for real notches)
@@ -54,9 +54,7 @@ class NotchViewModel: NSObject, ObservableObject {
     deinit {
         // === CLEANUP ===
         // Ensure proper cleanup when view model is deallocated
-        Task { @MainActor in
-            destroy()
-        }
+        destroy()
     }
 
     // === ANIMATION CONFIGURATION ===
@@ -186,7 +184,7 @@ class NotchViewModel: NSObject, ObservableObject {
      * Clean shutdown - cancel all event subscriptions and free resources
      * Critical for preventing memory leaks and cleaning up global event monitors
      */
-    func destroy() {
+    nonisolated func destroy() {
         cancellables.forEach { $0.cancel() }   // Cancel all Combine subscriptions
         cancellables.removeAll()               // Clear the storage array
     }

--- a/NotchUtility/Views/NotchOverlayView.swift
+++ b/NotchUtility/Views/NotchOverlayView.swift
@@ -142,7 +142,7 @@ struct NotchOverlayView: View {
             .contentShape(Rectangle())
             .frame(width: notchSize.width + vm.dropDetectorRange, height: notchSize.height + vm.dropDetectorRange)
             .onDrop(of: [.data], isTargeted: $dropTargeting) { _ in true }
-            .onChange(of: dropTargeting) { isTargeted in
+            .onChange(of: dropTargeting) { _, isTargeted in
                 if isTargeted, vm.status == .closed {
                     vm.notchOpen(.drag)
                     vm.hapticSender.send()


### PR DESCRIPTION
Capture of 'self' in a closure that outlives deinit; this is an error in the Swift 6 language mode

Deal with the following warnings:

NotchUtility/NotchUtility/Services/DropUtility.swift:18:26 Result of call to 'loadObject(ofClass:completionHandler:)' is unused
NotchUtility/NotchUtility/ViewModels/NotchViewModel.swift:57:14 Capture of 'self' in a closure that outlives deinit; this is an error in the Swift 6 language mode
NotchUtility/NotchUtility/ViewModels/NotchViewModel+Events.swift:149:27 Variable 'self' was written to, but never read
NotchUtility/NotchUtility/Views/NotchOverlayView.swift:145:14 'onChange(of:perform:)' was deprecated in macOS 14.0: Use onChange with a two or zero parameter action closure instead.